### PR TITLE
utilize `@Inject` with methods annotated `@Produces`

### DIFF
--- a/src/main/java/io/openliberty/sample/jakarta/finish/InventoryResource.java
+++ b/src/main/java/io/openliberty/sample/jakarta/finish/InventoryResource.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -20,6 +21,13 @@ public class InventoryResource {
 
 	@Inject
 	private VaccineInventoryBean vaccineInventory;
+	
+	@Inject @Named("firstDose")
+	private Alert firstDose;
+	
+	
+	@Inject @Named("secondDose")
+	private Alert secondDose;
 	
 	@GET
 	@Path("/inventory")
@@ -41,25 +49,25 @@ public class InventoryResource {
 	
 	// Producer methods 
 	
-	@Produces
-	public Alert firstDose() {
+	@Produces @Named("firstDose")
+	public static Alert firstDose() {
 		return new Alert("Time for your first dose!");
 	}
 	
-	@Produces
-	public Alert secondDose() {
+	@Produces @Named ("secondDose")
+	public static Alert secondDose() {
 		return new Alert("Time for your second dose!");
 	}
 	
 	@GET
 	@Path("/firstDose")
 	public String getFirstDoseMsg() {
-		return firstDose().sendAlert();
+		return firstDose.sendAlert();
 	}
 
 	@GET
 	@Path("/secondDose")
 	public String getSecondDoseMsg() {
-		return secondDose().sendAlert();
+		return secondDose.sendAlert();
 	}
 }


### PR DESCRIPTION
- Instead of having the methods annotated with `@Produces` return instances of `Alert` – one for the first dose and one for the second – we have the alert for the first and second dose injected by the runtime by using `@Inject` on the fields.